### PR TITLE
Feature/polymorphic authorizations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ trim_trailing_whitespace = true
 
 [*.{scss,sass}]
 indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -15,4 +15,4 @@ django-cors-middleware
 django-markup
 
 djangorestframework
-vng-api-common[notifications]==0.44.0
+vng-api-common[notifications]==0.46.1

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -15,4 +15,4 @@ django-cors-middleware
 django-markup
 
 djangorestframework
-vng-api-common[notifications]==0.43.3
+vng-api-common[notifications]==0.44.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,5 +48,5 @@ unidecode==1.0.23         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
 uwsgi==2.0.18
-vng-api-common[notifications]==0.43.3
+vng-api-common[notifications]==0.44.0
 webencodings==0.5.1       # via bleach

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,5 +48,5 @@ unidecode==1.0.23         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
 uwsgi==2.0.18
-vng-api-common[notifications]==0.44.0
+vng-api-common[notifications]==0.46.1
 webencodings==0.5.1       # via bleach

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -73,7 +73,7 @@ unidecode==1.0.23
 uritemplate==3.0.0
 urllib3==1.24.3
 uwsgi==2.0.18
-vng-api-common[notifications]==0.43.3
+vng-api-common[notifications]==0.44.0
 waitress==1.2.1           # via webtest
 webencodings==0.5.1
 webob==1.8.5              # via webtest

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -73,7 +73,7 @@ unidecode==1.0.23
 uritemplate==3.0.0
 urllib3==1.24.3
 uwsgi==2.0.18
-vng-api-common[notifications]==0.44.0
+vng-api-common[notifications]==0.46.1
 waitress==1.2.1           # via webtest
 webencodings==0.5.1
 webob==1.8.5              # via webtest

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -74,7 +74,7 @@ unidecode==1.0.23
 uritemplate==3.0.0
 urllib3==1.24.3
 uwsgi==2.0.18
-vng-api-common[notifications]==0.44.0
+vng-api-common[notifications]==0.46.1
 waitress==1.2.1
 webencodings==0.5.1
 webob==1.8.5

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -74,7 +74,7 @@ unidecode==1.0.23
 uritemplate==3.0.0
 urllib3==1.24.3
 uwsgi==2.0.18
-vng-api-common[notifications]==0.43.3
+vng-api-common[notifications]==0.44.0
 waitress==1.2.1
 webencodings==0.5.1
 webob==1.8.5

--- a/src/ac/api/tests/test_authorizations_api.py
+++ b/src/ac/api/tests/test_authorizations_api.py
@@ -1,7 +1,9 @@
 from rest_framework import status
 from rest_framework.test import APITestCase
 from vng_api_common.authorizations.models import Applicatie, Autorisatie
-from vng_api_common.constants import VertrouwelijkheidsAanduiding
+from vng_api_common.constants import (
+    ComponentTypes, VertrouwelijkheidsAanduiding
+)
 from vng_api_common.tests import (
     JWTAuthMixin, get_operation_url, get_validation_errors
 )
@@ -54,7 +56,7 @@ class SetAuthorizationsTests(JWTAuthMixin, APITestCase):
             'client_ids': ['id1', 'id2'],
             'label': 'Melding Openbare Ruimte consumer',
             'autorisaties': [{
-                'component': 'ZRC',
+                'component': ComponentTypes.zrc,
                 'scopes': [
                     'zds.scopes.zaken.lezen',
                     'zds.scopes.zaken.aanmaken',
@@ -62,7 +64,7 @@ class SetAuthorizationsTests(JWTAuthMixin, APITestCase):
                 'zaaktype': 'https://ref.tst.vng.cloud/zrc/api/v1/catalogus/1/zaaktypen/1',
                 'maxVertrouwelijkheidaanduiding': VertrouwelijkheidsAanduiding.beperkt_openbaar,
             }, {
-                'component': 'ZRC',
+                'component': ComponentTypes.zrc,
                 'scopes': [
                     'zds.scopes.zaken.lezen',
                     'zds.scopes.zaken.aanmaken',
@@ -88,7 +90,7 @@ class SetAuthorizationsTests(JWTAuthMixin, APITestCase):
         auth1, auth2 = autorisaties
 
         self.assertEqual(auth1.applicatie, applicatie)
-        self.assertEqual(auth1.component, 'ZRC')
+        self.assertEqual(auth1.component, ComponentTypes.zrc)
         self.assertEqual(auth1.zaaktype, 'https://ref.tst.vng.cloud/zrc/api/v1/catalogus/1/zaaktypen/1')
         self.assertEqual(
             auth1.scopes,
@@ -96,7 +98,7 @@ class SetAuthorizationsTests(JWTAuthMixin, APITestCase):
         )
         self.assertEqual(auth1.max_vertrouwelijkheidaanduiding, VertrouwelijkheidsAanduiding.beperkt_openbaar)
         self.assertEqual(auth2.applicatie, applicatie)
-        self.assertEqual(auth2.component, 'ZRC')
+        self.assertEqual(auth2.component, ComponentTypes.zrc)
         self.assertEqual(
             auth2.scopes,
             ['zds.scopes.zaken.lezen', 'zds.scopes.zaken.aanmaken', 'zds.scopes.zaken.verwijderen']
@@ -117,7 +119,7 @@ class SetAuthorizationsTests(JWTAuthMixin, APITestCase):
             'label': 'Melding Openbare Ruimte consumer',
             'heeftAlleAutorisaties': True,
             'autorisaties': [{
-                'component': 'ZRC',
+                'component': ComponentTypes.zrc,
                 'scopes': [
                     'zds.scopes.zaken.lezen',
                     'zds.scopes.zaken.aanmaken',
@@ -207,7 +209,7 @@ class SetAuthorizationsTests(JWTAuthMixin, APITestCase):
             'label': 'Melding Openbare Ruimte consumer',
             'heeftAlleAutorisaties': None,
             'autorisaties': [{
-                'component': 'ZRC',
+                'component': ComponentTypes.zrc,
                 'scopes': [
                     'zds.scopes.zaken.lezen',
                     'zds.scopes.zaken.aanmaken',
@@ -234,8 +236,9 @@ class ReadAuthorizationsTests(JWTAuthMixin, APITestCase):
 
         AutorisatieFactory.create(
             applicatie__client_ids=['id1', 'id2'],
-            zaaktype='https://example.com',
+            component=ComponentTypes.zrc,
             scopes=['dummy.scope'],
+            zaaktype='https://example.com',
             max_vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.openbaar,
         )
 
@@ -265,8 +268,9 @@ class UpdateAuthorizationsTests(JWTAuthMixin, APITestCase):
 
         autorisatie = AutorisatieFactory.create(
             applicatie__client_ids=['id1', 'id2'],
-            zaaktype='https://example.com',
+            component=ComponentTypes.zrc,
             scopes=['dummy.scope'],
+            zaaktype='https://example.com',
             max_vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.openbaar,
         )
         cls.applicatie = autorisatie.applicatie
@@ -285,7 +289,7 @@ class UpdateAuthorizationsTests(JWTAuthMixin, APITestCase):
         url = get_operation_url('applicatie_partial_update', uuid=self.applicatie.uuid)
         data = {
             'autorisaties': [{
-                'component': 'ZRC',
+                'component': ComponentTypes.zrc,
                 'scopes': [
                     'zds.scopes.zaken.lezen',
                     'zds.scopes.zaken.aanmaken',
@@ -293,7 +297,7 @@ class UpdateAuthorizationsTests(JWTAuthMixin, APITestCase):
                 'maxVertrouwelijkheidaanduiding': VertrouwelijkheidsAanduiding.beperkt_openbaar,
                 'zaaktype': 'https://ref.tst.vng.cloud/zrc/api/v1/catalogus/1/zaaktypen/1',
             }, {
-                'component': 'ZRC',
+                'component': ComponentTypes.zrc,
                 'scopes': [
                     'zds.scopes.zaken.lezen',
                     'zds.scopes.zaken.aanmaken',

--- a/src/ac/api/tests/test_dso_api_strategy.py
+++ b/src/ac/api/tests/test_dso_api_strategy.py
@@ -64,7 +64,7 @@ class DSOApi50Tests(APITestCase):
                 'title': 'Invalid input.',
                 'status': 400,
                 'detail': '',
-                'invalid-params': [{
+                'invalid_params': [{
                     'name': 'foo',
                     'code': 'validation-error',
                     'reason': 'Invalid data.',

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -983,9 +983,9 @@ components:
       required: true
   securitySchemes:
     JWT-Claims:
-      type: http
-      scheme: bearer
       bearerFormat: JWT
+      scheme: bearer
+      type: http
   schemas:
     AutorisatieBase:
       required:
@@ -1208,7 +1208,7 @@ components:
       - status
       - detail
       - instance
-      - invalid-params
+      - invalidParams
       type: object
       properties:
         type:
@@ -1240,7 +1240,7 @@ components:
             Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
           type: string
           minLength: 1
-        invalid-params:
+        invalidParams:
           type: array
           items:
             $ref: '#/components/schemas/FieldValidationError'

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -987,7 +987,7 @@ components:
       scheme: bearer
       bearerFormat: JWT
   schemas:
-    Autorisatie:
+    AutorisatieBase:
       required:
       - component
       - scopes
@@ -1033,6 +1033,11 @@ components:
             type: string
             maxLength: 100
             minLength: 1
+      discriminator:
+        propertyName: component
+    ZRCAutorisatie:
+      type: object
+      properties:
         zaaktype:
           title: Zaaktype
           description: URL naar het zaaktype waarop de autorisatie van toepassing
@@ -1053,6 +1058,54 @@ components:
           - confidentieel
           - geheim
           - zeer geheim
+    ZRC:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/AutorisatieBase'
+      - $ref: '#/components/schemas/ZRCAutorisatie'
+    DRCAutorisatie:
+      type: object
+      properties:
+        informatieobjecttype:
+          title: Informatieobjecttype
+          description: URL naar het informatieobjecttype waarop de autorisatie van
+            toepassing is.
+          type: string
+          format: uri
+          maxLength: 1000
+        maxVertrouwelijkheidaanduiding:
+          title: Max vertrouwelijkheidaanduiding
+          description: Maximaal toegelaten vertrouwelijkheidaanduiding (inclusief).
+          type: string
+          enum:
+          - openbaar
+          - beperkt openbaar
+          - intern
+          - zaakvertrouwelijk
+          - vertrouwelijk
+          - confidentieel
+          - geheim
+          - zeer geheim
+    DRC:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/AutorisatieBase'
+      - $ref: '#/components/schemas/DRCAutorisatie'
+    BRCAutorisatie:
+      type: object
+      properties:
+        besluittype:
+          title: Besluittype
+          description: URL naar het besluittype waarop de autorisatie van toepassing
+            is.
+          type: string
+          format: uri
+          maxLength: 1000
+    BRC:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/AutorisatieBase'
+      - $ref: '#/components/schemas/BRCAutorisatie'
     Applicatie:
       required:
       - clientIds
@@ -1087,7 +1140,7 @@ components:
         autorisaties:
           type: array
           items:
-            $ref: '#/components/schemas/Autorisatie'
+            $ref: '#/components/schemas/AutorisatieBase'
     Fout:
       required:
       - code

--- a/src/resources.md
+++ b/src/resources.md
@@ -4,27 +4,6 @@ Dit document beschrijft de (RGBZ-)objecttypen die als resources ontsloten
 worden met de beschikbare attributen.
 
 
-## Autorisatie
-
-Objecttype op [GEMMA Online](https://www.gemmaonline.nl/index.php/Rgbz_1.0/doc/objecttype/autorisatie)
-
-| Attribuut | Omschrijving | Type | Verplicht | CRUD* |
-| --- | --- | --- | --- | --- |
-| component | Component waarop autorisatie van toepassing is.
-
-De mapping van waarden naar weergave is als volgt:
-
-* `AC` - Autorisatiecomponent
-* `NRC` - Notificatierouteringcomponent
-* `ZRC` - Zaakregistratiecomponent
-* `ZTC` - Zaaktypecatalogus
-* `DRC` - Documentregistratiecomponent
-* `BRC` - Besluitregistratiecomponent | string | ja | C​R​U​D |
-| componentWeergave |  | string | nee | ~~C~~​R​~~U~~​~~D~~ |
-| scopes | Komma-gescheiden lijst van scope labels. | array | ja | C​R​U​D |
-| zaaktype | URL naar het zaaktype waarop de autorisatie van toepassing is. | string | nee | C​R​U​D |
-| maxVertrouwelijkheidaanduiding | Maximaal toegelaten vertrouwelijkheidaanduiding (inclusief). | string | nee | C​R​U​D |
-
 ## Applicatie
 
 Objecttype op [GEMMA Online](https://www.gemmaonline.nl/index.php/Rgbz_1.0/doc/objecttype/applicatie)

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -22,9 +22,9 @@
     ],
     "securityDefinitions": {
         "JWT-Claims": {
-            "type": "http",
+            "bearerFormat": "JWT",
             "scheme": "bearer",
-            "bearerFormat": "JWT"
+            "type": "http"
         }
     },
     "security": [
@@ -1359,7 +1359,7 @@
                 "status",
                 "detail",
                 "instance",
-                "invalid-params"
+                "invalidParams"
             ],
             "type": "object",
             "properties": {
@@ -1397,7 +1397,7 @@
                     "type": "string",
                     "minLength": 1
                 },
-                "invalid-params": {
+                "invalidParams": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/FieldValidationError"

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -1097,7 +1097,7 @@
         }
     },
     "definitions": {
-        "Autorisatie": {
+        "AutorisatieBase": {
             "required": [
                 "component",
                 "scopes"
@@ -1132,7 +1132,13 @@
                         "maxLength": 100,
                         "minLength": 1
                     }
-                },
+                }
+            },
+            "discriminator": "component"
+        },
+        "ZRCAutorisatie": {
+            "type": "object",
+            "properties": {
                 "zaaktype": {
                     "title": "Zaaktype",
                     "description": "URL naar het zaaktype waarop de autorisatie van toepassing is.",
@@ -1156,6 +1162,78 @@
                     ]
                 }
             }
+        },
+        "ZRC": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/AutorisatieBase"
+                },
+                {
+                    "$ref": "#/definitions/ZRCAutorisatie"
+                }
+            ]
+        },
+        "DRCAutorisatie": {
+            "type": "object",
+            "properties": {
+                "informatieobjecttype": {
+                    "title": "Informatieobjecttype",
+                    "description": "URL naar het informatieobjecttype waarop de autorisatie van toepassing is.",
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 1000
+                },
+                "maxVertrouwelijkheidaanduiding": {
+                    "title": "Max vertrouwelijkheidaanduiding",
+                    "description": "Maximaal toegelaten vertrouwelijkheidaanduiding (inclusief).",
+                    "type": "string",
+                    "enum": [
+                        "openbaar",
+                        "beperkt openbaar",
+                        "intern",
+                        "zaakvertrouwelijk",
+                        "vertrouwelijk",
+                        "confidentieel",
+                        "geheim",
+                        "zeer geheim"
+                    ]
+                }
+            }
+        },
+        "DRC": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/AutorisatieBase"
+                },
+                {
+                    "$ref": "#/definitions/DRCAutorisatie"
+                }
+            ]
+        },
+        "BRCAutorisatie": {
+            "type": "object",
+            "properties": {
+                "besluittype": {
+                    "title": "Besluittype",
+                    "description": "URL naar het besluittype waarop de autorisatie van toepassing is.",
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 1000
+                }
+            }
+        },
+        "BRC": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/AutorisatieBase"
+                },
+                {
+                    "$ref": "#/definitions/BRCAutorisatie"
+                }
+            ]
         },
         "Applicatie": {
             "required": [
@@ -1195,7 +1273,7 @@
                 "autorisaties": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/Autorisatie"
+                        "$ref": "#/definitions/AutorisatieBase"
                     }
                 }
             }


### PR DESCRIPTION
Added support for polymorphism, so that we can expose different extra attributes per component.

This is needed to add AC to the DRC.

The core functionality is implemented in vng-api-common, which has the 'smart' serializers to (de)serialize the objects.