### PR TITLE
Fixed wrong scope in autorisatie validation test

### DIFF
--- a/src/ac/api/tests/test_authorizations_api.py
+++ b/src/ac/api/tests/test_authorizations_api.py
@@ -485,7 +485,7 @@ class AuthorizationValidationTests(JWTAuthMixin, APITestCase):
                     },
                     {
                         "component": "zrc",
-                        "scopes": ["besluiten.lezen"],
+                        "scopes": ["zaken.lezen"],
                         "zaaktype": "https://example.com",
                         "maxVertrouwelijkheidaanduiding": "",
                     },


### PR DESCRIPTION
because the new validator checks the scopes before validating on required fields