### PR TITLE
Bump vng-api-common to 1.0.22

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -49,5 +49,5 @@ unidecode==1.0.23         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
 uwsgi==2.0.18
-vng-api-common==1.0.18
+vng-api-common==1.0.22
 webencodings==0.5.1       # via bleach

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -67,6 +67,6 @@ unidecode==1.0.23
 uritemplate==3.0.0
 urllib3==1.24.3
 uwsgi==2.0.18
-vng-api-common==1.0.18
+vng-api-common==1.0.22
 webencodings==0.5.1
 wrapt==1.11.1             # via astroid

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -68,6 +68,6 @@ unidecode==1.0.23
 uritemplate==3.0.0
 urllib3==1.24.3
 uwsgi==2.0.18
-vng-api-common==1.0.18
+vng-api-common==1.0.22
 webencodings==0.5.1
 wrapt==1.11.1


### PR DESCRIPTION
to implement scope specific autorisation validation